### PR TITLE
Change functions to `static inline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <assert.h>
 
-#define ITER_IMPL
 #include "iter.h"
 
 bool filter_odds(int* item) {

--- a/iter.h
+++ b/iter.h
@@ -7,8 +7,7 @@
 	```c
 	#include <stdio.h>
 	#include <assert.h>
-	
-	#define ITER_IMPL
+
 	#include "iter.h"
 
 	bool filter_odds(int* item) {
@@ -64,18 +63,12 @@ typedef struct LinIter {
 	size_t items_left;
 } LinIter;
 
-// Advances `struct LinIter`
-ITERDEF void* LinIter_next(LinIter* self);
-
 // Map iterator. Maps each value using a the `.mapfn()`.
 typedef struct MapIter {
 	void* (*next)(struct MapIter* self);
 	Iter* child;
 	void* (*mapfn)(void* item);
 } MapIter;
-
-// Advances `struct MapIter`
-ITERDEF void* MapIter_next(MapIter* self);
 
 // Chain iterator. Chains two iterators together.
 typedef struct ChainIter {
@@ -84,9 +77,6 @@ typedef struct ChainIter {
 	Iter* second;
 } ChainIter;
 
-// Advances `struct ChainIter`
-ITERDEF void* ChainIter_next(ChainIter* self);
-
 // Filter iterator. Only includes values from iterator if `.filter()`
 // returns `true`.
 typedef struct FilterIter {
@@ -94,9 +84,6 @@ typedef struct FilterIter {
 	Iter* child;
 	bool (*filter)(void* item);
 } FilterIter;
-
-// Advances `struct FilterIter`
-ITERDEF void* FilterIter_next(FilterIter* self);
 
 // Union of all peekable iterators. Saves the current value which can
 // be accessed at `.peeked`
@@ -108,9 +95,6 @@ union Peekable {
 		void* _padding[1];
 	};
 };
-
-// Advances `union Peekable`
-ITERDEF void* Peekable_next(Peekable* self);
 
 // Complete union of all iterator types. Call `.next()` to advance
 // the iterator.
@@ -128,35 +112,8 @@ union Iter {
 	Peekable _peekable;
 };
 
-// Creates a new linear iterator `struct LinIter`.
-ITERDEF Iter liter(void* data, size_t count, size_t item_size);
-
-// Consumes every item in `iter`.
-ITERDEF void foreach(Iter iter, void (*consumer)(void* item));
-// Creates a mapped iterator `struct MapIter` with `mapfn`.
-ITERDEF Iter map(Iter* child, void* (*mapfn)(void* item));
-// Counts the number of items in `iter`.
-ITERDEF size_t count(Iter iter);
-// Gets the `n`th item in `iter`.
-ITERDEF void* nth(Iter iter, size_t n);
-// Combines two iterators together into a chained iterator
-// `struct ChainIter`.
-ITERDEF Iter chain(Iter* first, Iter* second);
-// Filters the items in `child` with the `filter` function and creates
-// a filtered iterator `struct FilterIter`.
-ITERDEF Iter filter(Iter* child, bool (*filter)(void* item));
-// Finds the first next in `iter` that matches the search criteria
-// in `search`.
-ITERDEF void* find(Iter iter, bool (*search)(void* item));
-
-// Creates a new peekable iterator `union Peekable`
-ITERDEF Peekable peekable(Iter* child);
-// Advances `peekable` if the condition `cond` is met.
-ITERDEF void* next_if(Peekable* peekable, bool (*cond)(void* item));
-
-#ifdef ITER_IMPL
-
-ITERDEF void* LinIter_next(LinIter* self) {
+// Advances `struct LinIter`
+ITERDEF static inline void* LinIter_next(LinIter* self) {
 	if(!self->items_left) return NULL;
 	self->items_left--;
 	void* item = self->bottom;
@@ -164,12 +121,14 @@ ITERDEF void* LinIter_next(LinIter* self) {
 	return item;
 }
 
-ITERDEF void* MapIter_next(MapIter* self) {
+// Advances `struct MapIter`
+ITERDEF static inline void* MapIter_next(MapIter* self) {
 	void* item = self->child->next(self->child);
 	return item ? self->mapfn(item) : NULL;
 }
 
-ITERDEF void* ChainIter_next(ChainIter* self) {
+// Advances `struct ChainIter`
+ITERDEF static inline void* ChainIter_next(ChainIter* self) {
 	if(self->first) {
 		void* item = self->first->next(self->first);
 		if(item) return item;
@@ -178,70 +137,84 @@ ITERDEF void* ChainIter_next(ChainIter* self) {
 	return self->second->next(self->second);
 }
 
-ITERDEF void* FilterIter_next(FilterIter* self) {
+// Advances `struct FilterIter`
+ITERDEF static inline void* FilterIter_next(FilterIter* self) {
 	void* item;
 	while((item = self->child->next(self->child))
 			&& !self->filter(item));
 	return item;
 }
 
-ITERDEF void* Peekable_next(Peekable* self) {
+// Advances `union Peekable`
+ITERDEF static inline void* Peekable_next(Peekable* self) {
 	void* item = self->peeked;
 	self->peeked = self->child->next(self->child);
 	return item;
 }
 
-ITERDEF Iter liter(void* data, size_t count, size_t item_size) {
+// Creates a new linear iterator `struct LinIter`.
+ITERDEF static inline Iter liter(void* data, size_t count, size_t item_size) {
 	return (Iter) { ._lin = {
 		&LinIter_next, item_size, (uint8_t*) data, count,
 	}};
 }
 
-ITERDEF void foreach(Iter iter, void (*consumer)(void* item)) {
+// Consumes every item in `iter`.
+ITERDEF static inline void foreach(Iter iter, void (*consumer)(void* item)) {
 	for(void* item; (item = iter.next(&iter));) {
 		consumer(item);
 	}
 }
 
-ITERDEF Iter map(Iter* child, void* (*mapfn)(void* item)) {
+// Creates a mapped iterator `struct MapIter` with `mapfn`.
+ITERDEF static inline Iter map(Iter* child, void* (*mapfn)(void* item)) {
 	return (Iter) { ._map = {
 		&MapIter_next, child, mapfn,
 	}};
 }
 
-ITERDEF size_t count(Iter iter) {
+// Counts the number of items in `iter`.
+ITERDEF static inline size_t count(Iter iter) {
 	size_t count = 0;
 	while(iter.next(&iter)) count++;
 	return count;
 }
 
-ITERDEF void* nth(Iter iter, size_t n) {
+// Gets the `n`th item in `iter`.
+ITERDEF static inline void* nth(Iter iter, size_t n) {
 	for(void* item; (item = iter.next(&iter));) {
 		if(!n--) return item;
 	}
 	return NULL;
 }
 
-ITERDEF Iter chain(Iter* first, Iter* second) {
+// Combines two iterators together into a chained iterator
+// `struct ChainIter`.
+ITERDEF static inline Iter chain(Iter* first, Iter* second) {
 	return (Iter) { ._chain = {
 		&ChainIter_next, first, second,
 	}};
 }
 
-ITERDEF Iter filter(Iter* child, bool (*filter)(void* item)) {
+// Filters the items in `child` with the `filter` function and creates
+// a filtered iterator `struct FilterIter`.
+ITERDEF static inline Iter filter(Iter* child, bool (*filter)(void* item)) {
 	return (Iter) { ._filter = {
 		&FilterIter_next, child, filter,
 	}};
 }
 
-ITERDEF void* find(Iter iter, bool (*search)(void* item)) {
+// Finds the first next in `iter` that matches the search criteria
+// in `search`.
+ITERDEF static inline void* find(Iter iter, bool (*search)(void* item)) {
 	for(void* item; (item = iter.next(&iter));) {
 		if(search(item)) return item;
 	}
 	return NULL;
 }
 
-ITERDEF Peekable peekable(Iter* child) {
+// Creates a new peekable iterator `union Peekable`
+ITERDEF static inline Peekable peekable(Iter* child) {
 	Peekable peekable = {
 		&Peekable_next, NULL, child,
 	};
@@ -249,13 +222,12 @@ ITERDEF Peekable peekable(Iter* child) {
 	return peekable;
 }
 
-ITERDEF void* next_if(Peekable* peekable, bool (*cond)(void* item)) {
+// Advances `peekable` if the condition `cond` is met.
+ITERDEF static inline void* next_if(Peekable* peekable, bool (*cond)(void* item)) {
 	return cond(peekable->peeked)
 		? Peekable_next(peekable)
 		: NULL;
 }
-
-#endif
 
 // Inline `foreach()` alternative. Used like a `for`-loop.
 #define foreachinl(constexpr_iter, arg_decl) \


### PR DESCRIPTION
All the functions in iter.h are short enough to be good candidates for conventional inlining. Removes the need for macro definition hacks.